### PR TITLE
ページ切替時のスクロールを修正

### DIFF
--- a/assets/js/lesson.js
+++ b/assets/js/lesson.js
@@ -80,7 +80,7 @@ window.addEventListener("DOMContentLoaded", function() {
 
     prettyPrint();
 
-    document.body.scrollTop = 0;
+    window.scrollTo(0, 0);
   }
 
   function onhashchange() {


### PR DESCRIPTION
ページ切替時にスクロールTOPが動いていなかったのを修正しました。

``` js
document.body.scrollTop = 0;
```

実際にスクロールバーが出ていたのは `document.documentElement` (`html`) であったため、
`document.body.scrollTop` は常に0となっていました。

仕様的に `document.documentElement.scrollTop = 0` は`scroll()`メソッドを叩くので、
それと同じ事をする `window.scrollTo(0, 0)` を使うように変更しました。
- https://www.w3.org/TR/cssom-view-1/#dom-element-scrolltop

`scrollTop`が機能するのが`html` or `body`なのかは、DOCTYPEに依存するそうです。
- [html - document.body.scrollTop is always 0 in IE even when scrolling - Stack Overflow](http://stackoverflow.com/questions/2717252/document-body-scrolltop-is-always-0-in-ie-even-when-scrolling)
